### PR TITLE
Scipy update

### DIFF
--- a/megpy/equilibrium.py
+++ b/megpy/equilibrium.py
@@ -556,7 +556,7 @@ class Equilibrium():
             derived['a'] = bbbs_center['r']
 
         # compute LFS phi (toroidal flux in W/rad) grid from integrating q = d psi/d phi
-        derived['phi'] = integrate.cumtrapz(derived['qpsi'],derived['psi'],initial=0)
+        derived['phi'] = integrate.cumulative_trapezoid(derived['qpsi'],derived['psi'],initial=0)
 
         # construct the corresponding rho_tor grid
         if derived['phi'][-1] !=0:

--- a/megpy/tracer.py
+++ b/megpy/tracer.py
@@ -561,7 +561,7 @@ def contour(X,Y,Z=None,level=None,threshold=None,i_center=None,interp_method='no
 
         if symmetrise:
             R_sym = (contour_['X']+contour_['X'][::-1])/2
-            Z_sym = (contour_['Y']-contour_['Y'][::-1])/2+integrate.trapz(contour_['X']*contour_['Y'],contour_['Y'])/integrate.trapz(contour_['X'],contour_['Y'])
+            Z_sym = (contour_['Y']-contour_['Y'][::-1])/2+integrate.trapezoid(contour_['X']*contour_['Y'],contour_['Y'])/integrate.trapezoid(contour_['X'],contour_['Y'])
             contour_['X_sym']=R_sym
             contour_['Y_sym']=Z_sym
 


### PR DESCRIPTION
Updated `scipy.integrate` function names to account for deprecation in `1.12.0+`.