### PR TITLE
bugfix/numpy-downgrade

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "megpy"
-version = "2.0.0"
+version = "2.0.1"
 description = "megpy"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 ]
 
 dependencies = [
-  "numpy>=2",
+  "numpy>=1.26.4",
   "scipy",
   "matplotlib",
   "xarray",


### PR DESCRIPTION
Reduce the numpy dependency requirement from >=2 to >=1.26.4 for compatibility in MITIM.